### PR TITLE
Change background, border and padding for tool tips

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -339,7 +339,7 @@
             <section class="section" id="tooltip">
                 <h1 class="title">Tooltip</h1>
                 <div class="example">
-                    <span class="tool-tip has-box-shadow">Italic (I)</span>
+                    <span class="tool-tip">Italic (I)</span>
                 </div>
             </section>
 

--- a/sass/_tool-tip.sass
+++ b/sass/_tool-tip.sass
@@ -6,3 +6,5 @@
     line-height: 1em
     font-weight: $weight-medium
     padding: rem(5) rem(8)
+
+    @extend .has-box-shadow

--- a/sass/_tool-tip.sass
+++ b/sass/_tool-tip.sass
@@ -1,7 +1,8 @@
 .tool-tip
     border-radius: 3px
-    background: $white
+    border: 1px solid $grey
+    background: $white-smoke
     font-size: rem(12)
     line-height: 1em
     font-weight: $weight-medium
-    padding: rem(10) rem(16)
+    padding: rem(5) rem(8)


### PR DESCRIPTION
Some tweaks to make tool tips more similar to mock ups:

![image](https://user-images.githubusercontent.com/1152336/34096489-5d1f3c9e-e43a-11e7-8b1f-fd38a51484ce.png)

After these changes (background, border and reduced padding):

![image](https://user-images.githubusercontent.com/1152336/34096516-729b2af6-e43a-11e7-9e2d-4d2948b889d4.png)

Also have extended from `.has-drop-shadow` so that HTML can be simplified to `<span class="tool-tip">`
