### PR TITLE
Hub related tweaks

### DIFF
--- a/sass/atoms/_modal.sass
+++ b/sass/atoms/_modal.sass
@@ -1,6 +1,3 @@
 $modal-background-background-color: rgba($grey, .9)
 
-$modal-card-head-background-color: $blue
-$modal-card-title-color: $white
-
 @import 'bulma/sass/components/modal.sass'

--- a/sass/bulma/elements/_tabs.sass
+++ b/sass/bulma/elements/_tabs.sass
@@ -4,6 +4,7 @@
 
 $tabs-toggle-link-active-background-color: #d4d4d4
 $tabs-toggle-link-active-border-color: #c4c4c4
+$tabs-toggle-link-active-color: $text
 
 .tabs
   // Styles
@@ -13,3 +14,4 @@ $tabs-toggle-link-active-border-color: #c4c4c4
         a
           background-color: $tabs-toggle-link-active-background-color
           border-color: $tabs-toggle-link-active-border-color
+          color: $tabs-toggle-link-active-color

--- a/sass/config/bulma-overrides/_footer.sass
+++ b/sass/config/bulma-overrides/_footer.sass
@@ -4,7 +4,7 @@
 $footer-background-color: $primary
 $footer-padding: rem(40) rem(24)
 
-footer
+footer:not(.modal-card-foot)
     input[type="submit"],
     button[type="submit"]
         border-color: white !important

--- a/sass/stencila.sass
+++ b/sass/stencila.sass
@@ -2,7 +2,7 @@
 @charset 'utf-8'
 
 ////
-/// Bluma setup & initial variables.
+/// Bulma setup & initial variables.
 ////
 @import 'config/colours'
 @import 'config/variables'
@@ -23,7 +23,7 @@
 @import 'config/functions'
 
 ////
-/// atoms
+/// Atoms
 ////
 @import 'imports/atoms'
 @import 'imports/components'


### PR DESCRIPTION
**fix: modal colors and CTA.**
- Removing $blue color from modal headers/footers, updating font color to dark default.
- Removing white border from modal footer buttons.

![screenshot 2019-03-07 11 26 39](https://user-images.githubusercontent.com/10161095/53985402-58e09800-40d0-11e9-846e-c79857d7816b.png)


**fix(tabs): Updating segmented control to $dark color instead of green to simplify colors.**
<img width="1193" alt="screenshot 2019-03-07 11 59 17" src="https://user-images.githubusercontent.com/10161095/53985450-76adfd00-40d0-11e9-917d-7fa53fe37777.png">
